### PR TITLE
Fix misleading indentation warnings.

### DIFF
--- a/src/cell.cc
+++ b/src/cell.cc
@@ -228,13 +228,15 @@ void voronoicell_base::add_memory_vorder(vc_class &vc) {
 	fprintf(stderr,"Vertex order memory scaled up to %d\n",i);
 #endif
 	p1=new int[i];
-	for(j=0;j<current_vertex_order;j++) p1[j]=mem[j];while(j<i) p1[j++]=0;
+	for(j=0;j<current_vertex_order;j++) p1[j]=mem[j];
+	while(j<i) p1[j++]=0;
 	delete [] mem;mem=p1;
 	p2=new int*[i];
 	for(j=0;j<current_vertex_order;j++) p2[j]=mep[j];
 	delete [] mep;mep=p2;
 	p1=new int[i];
-	for(j=0;j<current_vertex_order;j++) p1[j]=mec[j];while(j<i) p1[j++]=0;
+	for(j=0;j<current_vertex_order;j++) p1[j]=mec[j];
+	while(j<i) p1[j++]=0;
 	delete [] mec;mec=p1;
 	vc.n_add_memory_vorder(i);
 	current_vertex_order=i;
@@ -290,7 +292,8 @@ void voronoicell_base::add_memory_xse() {
  * \param[in] (ymin,ymax) the minimum and maximum y coordinates.
  * \param[in] (zmin,zmax) the minimum and maximum z coordinates. */
 void voronoicell_base::init_base(double xmin,double xmax,double ymin,double ymax,double zmin,double zmax) {
-	for(int i=0;i<current_vertex_order;i++) mec[i]=0;up=0;
+	for(int i=0;i<current_vertex_order;i++) mec[i]=0;
+	up=0;
 	mec[3]=p=8;xmin*=2;xmax*=2;ymin*=2;ymax*=2;zmin*=2;zmax*=2;
 	*pts=xmin;pts[1]=ymin;pts[2]=zmin;
 	pts[4]=xmax;pts[5]=ymin;pts[6]=zmin;
@@ -317,7 +320,8 @@ void voronoicell_base::init_base(double xmin,double xmax,double ymin,double ymax
 /** Initializes an L-shaped Voronoi cell of a fixed size for testing the
  * convexity robustness. */
 void voronoicell::init_l_shape() {
-	for(int i=0;i<current_vertex_order;i++) mec[i]=0;up=0;
+	for(int i=0;i<current_vertex_order;i++) mec[i]=0;
+	up=0;
 	mec[3]=p=12;
 	const double j=0;
 	*pts=-2;pts[1]=-2;pts[2]=-2;
@@ -356,7 +360,8 @@ void voronoicell::init_l_shape() {
  *              vertices are initialized at (-l,0,0), (l,0,0), (0,-l,0),
  *              (0,l,0), (0,0,-l), and (0,0,l). */
 void voronoicell_base::init_octahedron_base(double l) {
-	for(int i=0;i<current_vertex_order;i++) mec[i]=0;up=0;
+	for(int i=0;i<current_vertex_order;i++) mec[i]=0;
+	up=0;
 	mec[4]=p=6;l*=2;
 	*pts=-l;pts[1]=0;pts[2]=0;
 	pts[4]=l;pts[5]=0;pts[6]=0;
@@ -382,7 +387,8 @@ void voronoicell_base::init_octahedron_base(double l) {
  * \param (x2,y2,z2) a position vector for the third vertex.
  * \param (x3,y3,z3) a position vector for the fourth vertex. */
 void voronoicell_base::init_tetrahedron_base(double x0,double y0,double z0,double x1,double y1,double z1,double x2,double y2,double z2,double x3,double y3,double z3) {
-	for(int i=0;i<current_vertex_order;i++) mec[i]=0;up=0;
+	for(int i=0;i<current_vertex_order;i++) mec[i]=0;
+	up=0;
 	mec[3]=p=4;
 	*pts=x0*2;pts[1]=y0*2;pts[2]=z0*2;
 	pts[4]=x1*2;pts[5]=y1*2;pts[6]=z1*2;

--- a/src/v_compute.cc
+++ b/src/v_compute.cc
@@ -973,7 +973,8 @@ inline void voro_compute<c_class>::add_list_memory(int*& qu_s,int*& qu_e) {
 	if(qu_s<=qu_e) {
 		while(qu_s<qu_e) *(qu_c++)=*(qu_s++);
 	} else {
-		while(qu_s<qu_l) *(qu_c++)=*(qu_s++);qu_s=qu;
+		while(qu_s<qu_l) *(qu_c++)=*(qu_s++);
+		qu_s=qu;
 		while(qu_s<qu_e) *(qu_c++)=*(qu_s++);
 	}
 	delete [] qu;


### PR DESCRIPTION
This PR resolves #1 by inserting newlines in a few locations that had warnings about misleading indentation with GCC 7.

@chr1shr Let me know if there is anything else you'd like me to do on this PR. I didn't see a contributing guide. Thanks!