### PR TITLE
fix resource leak in example

### DIFF
--- a/examples/no_release/import_freeman.cc
+++ b/examples/no_release/import_freeman.cc
@@ -47,4 +47,5 @@ int main() {
 		fflush(stdout);
 		fprintf(outputFile,"%d %e %e %e\n", id,x,y,z);
 	} while (cl.inc());
+	fclose(outputFile);
 }


### PR DESCRIPTION
Very minor fix - the only one that showed up when running `cppcheck` on
the entire voro++ codebase - great!