### PR TITLE
add lib name for options to avoid naming conflicts in cmake interface.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ endif(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CXX_FLAGS)
 ########################################################################
 # User input options                                                   #
 ########################################################################
-option(BUILD_SHARED_LIBS "Build shared libs" ON)
+option(VORO_BUILD_SHARED_LIBS "Build shared libs" ON)
 include(GNUInstallDirs)
 
 ########################################################################


### PR DESCRIPTION
I added the lib to my project and the current option name is a bit confusing.
Small modification to add a prefix for the option name.