### PR TITLE
CMake fix when library is used in project via FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,8 @@ set_target_properties(voro++ PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/src"
   SOVERSION ${SOVERSION})
 install(TARGETS voro++ EXPORT VORO_Targets LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-#for voto++.hh
-target_include_directories(voro++ PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/src> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+#for voro++.hh
+target_include_directories(voro++ PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
 add_executable(cmd_line src/cmd_line.cc)
 target_link_libraries(cmd_line PRIVATE voro++)
@@ -55,7 +55,7 @@ endforeach(SOURCE)
 
 file(GLOB_RECURSE VORO_HEADERS src/voro++.hh)
 install(FILES ${VORO_HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-install(FILES ${CMAKE_SOURCE_DIR}/man/voro++.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/man/voro++.1 DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 # no external deps for we can use target file as config file
 install(EXPORT VORO_Targets FILE VOROConfig.cmake NAMESPACE VORO:: DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/VORO)
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
I use voro++ in a CMake project via something like

```
FetchContent_Declare(
        VORO
        GIT_REPOSITORY https://github.com/cbyrohl/voro)
FetchContent_MakeAvailable(VORO)
target_link_libraries(PROJECT PRIVATE voro++)
```

In certain cases, such as building all tests, including those from voro++, the voro++.hh cannot be found. This seems to be fixed by adjusting CMAKE_SOURCE_DIR => CMAKE_CURRENT_SOURCE_DIR.
