### PR TITLE
Stabilize 3D radical/power pruning across architectures by inflating max_radius by 1 ULP

### DIFF
--- a/src/container_3d.cc
+++ b/src/container_3d.cc
@@ -286,7 +286,9 @@ void container_poly_3d::put(int n,double x,double y,double z,double r) {
         id[ijk][co[ijk]]=n;
         double *pp=p[ijk]+4*co[ijk]++;
         *(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
-        if(max_radius<r) max_radius=r;
+        // Store a slightly inflated maximum radius to avoid borderline
+        // floating-point pruning decisions in radical (power diagram) mode.
+        if(r>=max_radius) max_radius=nextafter(r,HUGE_VAL);
     }
 }
 
@@ -351,7 +353,8 @@ void container_poly_3d::put_reconcile_overflow() {
 
     // Compute the global maximum radius using the per-thread values
     for(int i=0;i<nt;i++) {
-        if(max_radius<max_r[i]) max_radius=max_r[i];
+        // Merge per-thread maxima and keep max_radius slightly inflated (see comment above).
+        if(max_r[i]>=max_radius) max_radius=nextafter(max_r[i],HUGE_VAL);
         max_r[i]=0.;
     }
 
@@ -403,7 +406,9 @@ void container_poly_3d::put(particle_order &vo,int n,double x,double y,double z,
         vo.add(ijk,co[ijk]);
         double *pp=p[ijk]+4*co[ijk]++;
         *(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
-        if(max_radius<r) max_radius=r;
+        // Store a slightly inflated maximum radius to avoid borderline
+        // floating-point pruning decisions in radical (power diagram) mode.
+        if(r>=max_radius) max_radius=nextafter(r,HUGE_VAL);
     }
 }
 

--- a/src/container_3d.hh
+++ b/src/container_3d.hh
@@ -508,7 +508,9 @@ class container_poly_3d : public container_base_3d, public radius_poly_3d {
             if(put_locate_block(ijk,x,y,z)) {
                 double *pp=p[ijk]+4*co[ijk]++,tm=max_radius;
                 *(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
-                if(r>max_radius) max_radius=r;
+                // Store a slightly inflated maximum radius to avoid borderline
+                // floating-point pruning decisions in radical (power diagram) mode.
+                if(r>=max_radius) max_radius=nextafter(r,HUGE_VAL);
                 bool q=compute_cell(c,ijk,co[ijk]-1);
                 co[ijk]--;max_radius=tm;
                 return q;

--- a/src/container_tri.cc
+++ b/src/container_tri.cc
@@ -335,7 +335,8 @@ void container_triclinic_poly::put_reconcile_overflow() {
 
     // Compute the global maximum radius using the per-thread values
     for(int i=0;i<nt;i++) {
-        if(max_radius<max_r[i]) max_radius=max_r[i];
+        // Merge per-thread maxima and keep max_radius slightly inflated.
+        if(max_r[i]>=max_radius) max_radius=nextafter(max_r[i],HUGE_VAL);
         max_r[i]=0.;
     }
 
@@ -380,7 +381,9 @@ void container_triclinic_poly::put(int n,double x,double y,double z,double r) {
     id[ijk][co[ijk]]=n;
     double *pp=p[ijk]+4*co[ijk]++;
     *(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
-    if(max_radius<r) max_radius=r;
+    // Store a slightly inflated maximum radius to avoid borderline
+    // floating-point pruning decisions in radical (power diagram) mode.
+    if(r>=max_radius) max_radius=nextafter(r,HUGE_VAL);
 }
 
 /** Put a particle into the correct region of the container.
@@ -410,7 +413,9 @@ void container_triclinic_poly::put(int n,double x,double y,double z,double r,int
     id[ijk][co[ijk]]=n;
     double *pp=p[ijk]+4*co[ijk]++;
     *(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
-    if(max_radius<r) max_radius=r;
+    // Store a slightly inflated maximum radius to avoid borderline
+    // floating-point pruning decisions in radical (power diagram) mode.
+    if(r>=max_radius) max_radius=nextafter(r,HUGE_VAL);
 }
 
 /** Put a particle into the correct region of the container, also recording
@@ -440,7 +445,9 @@ void container_triclinic_poly::put(particle_order &vo,int n,double x,double y,do
     vo.add(ijk,co[ijk]);
     double *pp=p[ijk]+4*co[ijk]++;
     *(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
-    if(max_radius<r) max_radius=r;
+    // Store a slightly inflated maximum radius to avoid borderline
+    // floating-point pruning decisions in radical (power diagram) mode.
+    if(r>=max_radius) max_radius=nextafter(r,HUGE_VAL);
 }
 
 /** Takes a particle position vector and computes the region index into which

--- a/src/container_tri.hh
+++ b/src/container_tri.hh
@@ -532,7 +532,9 @@ class container_triclinic_poly : public container_triclinic_base, public radius_
             put_locate_block(ijk,x,y,z);
             double *pp=p[ijk]+4*co[ijk]++,tm=max_radius;
             *(pp++)=x;*(pp++)=y;*(pp++)=z;*pp=r;
-            if(r>max_radius) max_radius=r;
+            // Store a slightly inflated maximum radius to avoid borderline
+            // floating-point pruning decisions in radical (power diagram) mode.
+            if(r>=max_radius) max_radius=nextafter(r,HUGE_VAL);
             bool q=compute_cell(c,ijk,co[ijk]-1);
             co[ijk]--;max_radius=tm;
             return q;


### PR DESCRIPTION
Fixes #43 

**Context**
- Original report / discussion: #43   
- Reproduction + CI (now includes both stable and dev snapshots, and demonstrates the fix): https://github.com/IvanChernyshov/voro_repro

**Summary**
This PR fixes a platform-/codegen-dependent robustness issue in the 3D radical (power diagram) containers. In some builds (notably on macOS/ARM64, and also reproducible on Linux with more aggressive FP codegen), the computation can become under-clipped: a cell misses required cutting planes, causing non-reciprocal neighbor relationships and (in a fully periodic orthorhombic box) a total volume sum that exceeds the box volume.

**Root cause (short)**
In radical mode Voro++ uses the global maximum particle radius `max_radius` as part of conservative cutoff/pruning tests. For the particle that actually has the maximum radius, the radical cutoff term becomes exactly:

    r_mul = r_i^2 - max_radius^2 = 0

This makes several pruning inequalities knife-edge. Small floating-point differences between platforms/compilers/optimization settings can flip borderline `>` decisions, causing required blocks/planes to be skipped. The author’s note is also relevant here: occasional rounding issues can disrupt convexity. (Negative neighbor IDs can be valid in periodic domains due to a particle’s periodic image; the failure here is additionally evidenced by broken reciprocity and the volume-sum mismatch.)

**Fix**
Store `max_radius` slightly above the observed maximum radius (1 ULP) using `nextafter`:

    max_radius = nextafter(r, HUGE_VAL);

This makes `r_mul` slightly negative for the max-radius particle, turning the knife-edge comparisons into strictly conservative ones. It can only make pruning slightly less aggressive (safe), and has negligible performance impact in practice.

**Scope**
This PR is intentionally limited to the 3D radical/power containers and updates all 3D code paths that assign/update `max_radius`, including ghost-cell helpers. (No 2D changes are included here.)

**Verification**
The reproduction [repo](https://github.com/IvanChernyshov/voro_repro) contains:
- the minimal repro program and dataset,
- CI steps that run original vs patched on Ubuntu and macOS,
- and an additional Linux “aggressive flags” build that reproduces the same failure mode and shows it fixed with this change.
